### PR TITLE
Fixes and Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note: R1 runs on all supported architectures (ARM, AARCH, MIPS). R2 runs only on
 
 # Version R2 (based on vnStat 2.x) #
 
-### v2.0.13 - 2026-Apr-06 ###
+### v2.0.13 - 2026-Apr-12 ###
   * FIXED: In some instances, one of the PNG images for the vnStat hourly, daily, monthly, summary, and top-10 reports is partially rendered on the webpage, so it appears "truncated" with a blank or white area showing at the bottom of the image.
     [see GitHub issue #40 for further details]
     https://github.com/AMTM-OSR/vnstat-on-merlin/issues/40
@@ -13,7 +13,13 @@ Note: R1 runs on all supported architectures (ARM, AARCH, MIPS). R2 runs only on
 
   * FIXED: A bug in the WebUI page was allowing users to save empty values for the "Maximum bandwidth data allowance" and the "Start day of the month for bandwidth usage data allowance" settings.
 
-  * IMPROVED: Added the following data usage warning percent thresholds: 80%, 85% and 95%. This results in sending more warning emails when the current data usage reaches or exceeds each threshold and is rapidly approaching 100% of the user's maximum monthly allowance.
+  * FIXED: Added "unset LD_LIBRARY_PATH" line as a workaround due to the latest Entware binaries using the RUNPATH embedded library search path mechanism instead of the previous RPATH method.
+
+  * IMPROVED: Added the following percent thresholds for data usage warnings: 80%, 85%, and 95%. This results in sending more warning emails in the event that the current bandwidth data usage rapidly approaches 100% of the user's maximum monthly allowance, and the ever-increasing data usage reaches or exceeds each warning threshold along the way.
+
+  * IMPROVED: Modified code to create slightly larger vnStat PNG images (hourly, daily, monthly, summary, and top-10 reports) for better readability.
+
+  * NEW: The default configuraion file (/opt/share/dn-vnstat.d/vnstat.conf.default) was updated to the 2.13 version.
 
   * Miscellaneous code improvements.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vnstat-on-merlin - _Release - R1 and R2_
 
 ## v2.0.13
-### Updated on 2026-Apr-06
+### Updated on 2026-Apr-12
 
 # README #
 

--- a/dn-vnstat.sh
+++ b/dn-vnstat.sh
@@ -11,7 +11,7 @@
 ## Forked from https://github.com/de-vnull/vnstat-on-merlin ##
 ##                                                          ##
 ##############################################################
-# Last Modified: 2026-Apr-05
+# Last Modified: 2026-Apr-11
 #-------------------------------------------------------------
 
 ########         Shellcheck directives     ######
@@ -36,7 +36,7 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="dn-vnstat"
 readonly SCRIPT_VERSION="v2.0.13"
-readonly SCRIPT_VERSTAG="26040520"
+readonly SCRIPT_VERSTAG="26041123"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/vnstat-on-merlin/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME.d"
@@ -117,6 +117,9 @@ readonly WarnBYLWct="\e[30;103m"
 readonly WarnBMGNct="\e[30;105m"
 
 ### End of output format variables ###
+
+# Workaround for Entware ELF binaries compiled with RUNPATH #
+unset LD_LIBRARY_PATH
 
 # Give priority to built-in binaries #
 export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"
@@ -532,21 +535,21 @@ Update_File()
 	then  ## vnstat config file ##
 		tmpfile="/tmp/$1"
 		Download_File "$SCRIPT_REPO/$1" "$tmpfile"
-		if [ ! -f "$SCRIPT_STORAGE_DIR/$1" ]
+		if [ ! -s "$SCRIPT_STORAGE_DIR/$1" ]
 		then
-			Download_File "$SCRIPT_REPO/$1" "$SCRIPT_STORAGE_DIR/$1.default"
+			Download_File "$SCRIPT_REPO/$1" "$SCRIPT_STORAGE_DIR/${1}.default"
 			Download_File "$SCRIPT_REPO/$1" "$SCRIPT_STORAGE_DIR/$1"
 			Print_Output true "$SCRIPT_STORAGE_DIR/$1 does not exist, downloading now." "$PASS"
-		elif [ -f "$SCRIPT_STORAGE_DIR/$1.default" ]
+		elif [ -s "$SCRIPT_STORAGE_DIR/${1}.default" ]
 		then
-			if ! diff -q "$tmpfile" "$SCRIPT_STORAGE_DIR/$1.default" >/dev/null 2>&1
+			if ! diff -q "$tmpfile" "$SCRIPT_STORAGE_DIR/${1}.default" >/dev/null 2>&1
 			then
-				Download_File "$SCRIPT_REPO/$1" "$SCRIPT_STORAGE_DIR/$1.default"
-				Print_Output true "New default version of $1 downloaded to $SCRIPT_STORAGE_DIR/$1.default, please compare against your $SCRIPT_STORAGE_DIR/$1" "$PASS"
+				Download_File "$SCRIPT_REPO/$1" "$SCRIPT_STORAGE_DIR/${1}.default"
+				Print_Output true "New default version of $1 downloaded to $SCRIPT_STORAGE_DIR/${1}.default, please compare against your $SCRIPT_STORAGE_DIR/$1" "$PASS"
 			fi
 		else
-			Download_File "$SCRIPT_REPO/$1" "$SCRIPT_STORAGE_DIR/$1.default"
-			Print_Output true "$SCRIPT_STORAGE_DIR/$1.default does not exist, downloading now. Please compare against your $SCRIPT_STORAGE_DIR/$1" "$PASS"
+			Download_File "$SCRIPT_REPO/$1" "$SCRIPT_STORAGE_DIR/${1}.default"
+			Print_Output true "$SCRIPT_STORAGE_DIR/${1}.default does not exist, downloading now. Please compare against your $SCRIPT_STORAGE_DIR/$1" "$PASS"
 		fi
 		rm -f "$tmpfile"
 	else
@@ -728,7 +731,7 @@ _GetConfigParam_()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2026-Mar-15] ##
+## Modified by Martinski W. [2026-Apr-10] ##
 ##----------------------------------------##
 Conf_Exists()
 {
@@ -737,48 +740,74 @@ Conf_Exists()
 	if [ -f "$VNSTAT_CONFIG" ]
 	then
 		restartvnstat=false
-		if ! grep -q "^MaxBandwidth 1000" "$VNSTAT_CONFIG"; then
+		if ! grep -q "^MaxBandwidth 1000" "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^MaxBandwidth.*$/MaxBandwidth 1000/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -q "^TimeSyncWait 10" "$VNSTAT_CONFIG"; then
+		if ! grep -q "^TimeSyncWait 10" "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^TimeSyncWait.*$/TimeSyncWait 10/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -q "^UpdateInterval 30" "$VNSTAT_CONFIG"; then
+		if ! grep -q "^UpdateInterval 30" "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^UpdateInterval.*$/UpdateInterval 30/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -qE "^UnitMode [0-2]$" "$VNSTAT_CONFIG"; then
+		if ! grep -qE "^UnitMode [0-2]$" "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^UnitMode.*$/UnitMode 2/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -qE "^RateUnitMode [0-1]$" "$VNSTAT_CONFIG"; then
+		if ! grep -qE "^RateUnitMode [0-1]$" "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^RateUnitMode.*$/RateUnitMode 1/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -q "^OutputStyle 0" "$VNSTAT_CONFIG"; then
+		if ! grep -q "^OutputStyle 0" "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^OutputStyle.*$/OutputStyle 0/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -q '^DayFormat "%Y-%m-%d"' "$VNSTAT_CONFIG"; then
+		if ! grep -q '^DayFormat "%Y-%m-%d"' "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^DayFormat.*$/DayFormat "%Y-%m-%d"/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -q '^TopFormat "%Y-%m-%d"' "$VNSTAT_CONFIG"; then
+		if ! grep -q '^TopFormat "%Y-%m-%d"' "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^TopFormat.*$/TopFormat "%Y-%m-%d"/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -q '^MonthFormat "%Y-%m"' "$VNSTAT_CONFIG"; then
+		if ! grep -q '^MonthFormat "%Y-%m"' "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^MonthFormat.*$/MonthFormat "%Y-%m"/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
-		if ! grep -q '^HeaderFormat "%Y-%b-%d %H:%M %a"' "$VNSTAT_CONFIG"; then
+		if ! grep -q '^HeaderFormat "%Y-%b-%d %H:%M %a"' "$VNSTAT_CONFIG"
+		then
 			sed -i 's/^HeaderFormat.*$/HeaderFormat "%Y-%b-%d %H:%M %a"/' "$VNSTAT_CONFIG"
+			restartvnstat=true
+		fi
+		if ! grep -qE '^CHeader[[:blank:]]+"FFE4B5"' "$VNSTAT_CONFIG"
+		then
+			sed -i 's/^CHeader[[:blank:]]\+.*$/CHeader         "FFE4B5"/' "$VNSTAT_CONFIG"
+			restartvnstat=true
+		fi
+		if ! grep -qE '^CHeaderDate[[:blank:]]+"0000FF"' "$VNSTAT_CONFIG"
+		then
+			sed -i 's/^CHeaderDate[[:blank:]]\+.*$/CHeaderDate     "0000FF"/' "$VNSTAT_CONFIG"
+			restartvnstat=true
+		fi
+		if ! grep -qE '^CHeaderTitle[[:blank:]]+"000000"' "$VNSTAT_CONFIG"
+		then
+			sed -i 's/^CHeaderTitle[[:blank:]]\+.*$/CHeaderTitle    "000000"/' "$VNSTAT_CONFIG"
 			restartvnstat=true
 		fi
 		if [ "$restartvnstat" = "true" ]
 		then
+			printf "\nPlease wait...\n"
 			/opt/etc/init.d/S33vnstat restart >/dev/null 2>&1
 			Generate_Images silent
 			Generate_Stats silent
@@ -2102,11 +2131,11 @@ Generate_Images()
 	interface="$(_GetInterfaceNameFromConfig_)"
 	outputs="s hg d t m"   # what images to generate #
 
-	$VNSTATI_COMMAND -s -i "$interface" -o "$IMAGE_OUTPUT_DIR/vnstat_s.png"
-	$VNSTATI_COMMAND -hg -i "$interface" -o "$IMAGE_OUTPUT_DIR/vnstat_hg.png"
-	$VNSTATI_COMMAND -d 31 -i "$interface" -o "$IMAGE_OUTPUT_DIR/vnstat_d.png"
-	$VNSTATI_COMMAND -m 12 -i "$interface" -o "$IMAGE_OUTPUT_DIR/vnstat_m.png"
-	$VNSTATI_COMMAND -t 10 -i "$interface" -o "$IMAGE_OUTPUT_DIR/vnstat_t.png"
+	$VNSTATI_COMMAND -s -i "$interface" -L -o "$IMAGE_OUTPUT_DIR/vnstat_s.png"
+	$VNSTATI_COMMAND -hg -i "$interface" -L -o "$IMAGE_OUTPUT_DIR/vnstat_hg.png"
+	$VNSTATI_COMMAND -d 31 -i "$interface" -L -o "$IMAGE_OUTPUT_DIR/vnstat_d.png"
+	$VNSTATI_COMMAND -m 12 -i "$interface" -L -o "$IMAGE_OUTPUT_DIR/vnstat_m.png"
+	$VNSTATI_COMMAND -t 10 -i "$interface" -L -o "$IMAGE_OUTPUT_DIR/vnstat_t.png"
 	sleep 1
 
 	for output in $outputs

--- a/vnstat.conf
+++ b/vnstat.conf
@@ -1,5 +1,8 @@
-# vnStat 2.6 config file
-##
+# vnStat 2.13 configuration file
+#
+# Last Updated: 2026-Apr-10
+# Lines starting with # or ; are comments.
+#
 
 # default interface (leave empty for automatic selection)
 Interface "eth0"
@@ -13,7 +16,7 @@ Locale "-"
 # date output formats for -d, -m, -t and -w
 # see 'man date' for control codes
 DayFormat "%Y-%m-%d"
-MonthFormat "%Y-%m (%d)"
+MonthFormat "%Y-%m"
 TopFormat "%Y-%m-%d"
 
 # characters used for visuals
@@ -41,6 +44,7 @@ RateUnitMode 1
 # 2 = same as 1 except rate in summary
 # 3 = rate column visible
 OutputStyle 0
+EstimateBarVisible 1
 
 # number of decimals to use in outputs
 DefaultDecimals 2
@@ -52,9 +56,12 @@ HourlySectionStyle 2
 # how many seconds should sampling for -tr take by default
 Sampletime 5
 
+# show animation at the beginning of -l / --live line (1 = enabled, 0 = disabled)
+;; LiveSpinner 1
+
 # default query mode
-# 0 = normal, 1 = days, 2 = months, 3 = top, 5 = short
-# 7 = hours, 8 = xml, 9 = one line, 10 = json
+# 0 = summary, 1 = days, 2 = months, 3 = top, 4 = single summary, 5 = short
+# 7 = hours graph, 8 = xml, 9 = one line, 10 = json, 11 = hours, 12 = 5 minute
 QueryMode 0
 
 # default list output entry limits (0 = all)
@@ -64,6 +71,20 @@ ListDays       31
 ListMonths     12
 ListYears       5
 ListTop        10
+
+# how to match interface given for query to interface in database
+# 0 = case sensitive exact match to interface name
+# 1 = method 0 followed by case sensitive exact match of alias
+# 2 = method 1 followed by case insensitive exact match of alias
+# 3 = method 2 followed by case insensitive beginning match of alias
+;; InterfaceMatchMethod 3
+
+# visibility of estimate line and text used in it
+EstimateVisible 1
+EstimateText "Estimated"
+
+# interface order (0 = alphabetical by name, 1 = alphabetical by alias)
+;; InterfaceOrder 0
 
 
 # vnstatd
@@ -84,8 +105,8 @@ BandwidthDetection 0
 MaxBandwidth 1000
 
 # interface specific limits
-#  example 8Mbit limit for 'ethnone':
-MaxBWethnone 8
+#  example 8Mbit limit for 'ethNone':
+MaxBWethNone 8
 
 # data retention durations (-1 = unlimited, 0 = feature disabled)
 5MinuteHours   720
@@ -106,6 +127,13 @@ SaveInterval 1
 
 # how often (in minutes) data is saved when all interface are offline
 OfflineSaveInterval 5
+
+# rescan database after save for new interfaces to be monitored (1 = enabled, 0 = disabled)
+;; RescanDatabaseOnSave 1
+
+# automatically start monitoring all interfaces not found in the database
+# (1 = enabled, 0 = disabled)
+;; AlwaysAddNewInterfaces 0
 
 # on which day should months change
 MonthRotate 1
@@ -163,11 +191,16 @@ DatabaseSynchronous -1
 # 1 = enabled, 0 = disabled.
 UseUTC 0
 
+# database maintenance (1 = enabled, 0 = disabled)
+;; VacuumOnStartup 1
+;; VacuumOnHUPSignal 1
+
+
 # vnstati
 ##
 
 # title timestamp format
-HeaderFormat "%d-%b-%Y %H:%M"
+HeaderFormat "%Y-%b-%d %H:%M %a"
 
 # show hours with rate (1 = enabled, 0 = disabled)
 HourlyRate 0
@@ -178,16 +211,41 @@ SummaryRate 0
 # transparent background (1 = enabled, 0 = disabled)
 TransparentBg 0
 
+# image size control
+LargeFonts 1
+LineSpacingAdjustment 0
+ImageScale 100
+
+# 5 minutes graph size control
+;; 5MinuteGraphResultCount 576
+;; 5MinuteGraphHeight 300
+
+# hourly graph mode (0 = 24 hour sliding window, 1 = begins from midnight)
+HourlyGraphMode 0
+
+# horizontal/vertical summary graph (0 = hours, 1 = 5 minutes)
+;; SummaryGraph 0
+
+# traffic estimate bar style
+# (0 = not shown, 1 = continuation of existing bar, 2 = separate bar)
+EstimateStyle 1
+
+# bar column in list outputs shows rate if OutputStyle is 3
+# (1 = enabled, 0 = disabled)
+;; BarColumnShowsRate 0
+
 # image colors
 CBackground     "475A5F"
 CEdge           "475A5F"
-CHeader         "475A5F"
-CHeaderTitle    "FFFFFF"
-CHeaderDate     "EAE303"
+CHeader         "FFE4B5"
+CHeaderTitle    "000000"
+CHeaderDate     "0000FF"
 CText           "FFFFFF"
 CLine           "B0B0B0"
 CLineL          "EAE303"
+CPercentileLine "CF0045"
 CRx             "C5C5CE"
 CTx             "0EC009"
 CRxD            "-"
 CTxD            "-"
+CTotal          "0098CF"


### PR DESCRIPTION
- Modified code to generate slightly larger and more readable vnStat PNG images (hourly, daily, monthly, summary, and top-10 reports).

- Added "`unset LD_LIBRARY_PATH`" line as a workaround due to the latest Entware binaries using the **RUNPATH** embedded library search path mechanism instead of the previous **RPATH** method.

- The default vnstat configuration file (`/opt/share/dn-vnstat.d/vnstat.conf.default`) was updated to the **2.13** version.

- Miscellaneous code improvements.